### PR TITLE
Refactor Attribute

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -17,12 +17,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-var (
-	errAttrKey             = "error"
-	v1EventTypeAttr        = attribute.String("event.type", "v1")
-	v2EventTypeAttr        = attribute.String("event.type", "v2")
-	websocketEventTypeAttr = attribute.String("event.type", "websocket")
-)
+var errAttrKey = "error"
 
 type AuthEvent struct {
 	Version string `json:"version,omitempty"`
@@ -95,7 +90,7 @@ func (h *Handler) RouteEvent(ctx context.Context, event any) (events.APIGatewayV
 
 	switch authEvent.Version {
 	case "1.0":
-		eventTypeAttr = v1EventTypeAttr
+		eventTypeAttr = attribute.String("event.type", "v1")
 		var v1Event events.APIGatewayV2CustomAuthorizerV1Request
 		if err := json.Unmarshal(eventJson, &v1Event); err != nil {
 			logger.Error(ctx, "error unmarshalling event", eventTypeAttr, attribute.String(errAttrKey, err.Error()))
@@ -105,7 +100,7 @@ func (h *Handler) RouteEvent(ctx context.Context, event any) (events.APIGatewayV
 		}
 
 	case "2.0":
-		eventTypeAttr = v2EventTypeAttr
+		eventTypeAttr = attribute.String("event.type", "v2")
 		var v2Event events.APIGatewayV2CustomAuthorizerV2Request
 		if err := json.Unmarshal(eventJson, &v2Event); err != nil {
 			logger.Error(ctx, "error unmarshalling event", eventTypeAttr, attribute.String(errAttrKey, err.Error()))
@@ -115,7 +110,7 @@ func (h *Handler) RouteEvent(ctx context.Context, event any) (events.APIGatewayV
 		}
 
 	default:
-		eventTypeAttr = websocketEventTypeAttr
+		eventTypeAttr = attribute.String("event.type", "websocket")
 		var websocketEvent events.APIGatewayWebsocketProxyRequest
 		if err := json.Unmarshal(eventJson, &websocketEvent); err != nil {
 			logger.Error(ctx, "error unmarshalling event", eventTypeAttr, attribute.String(errAttrKey, err.Error()))

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -14,9 +14,8 @@ import (
 )
 
 var (
-	eventStatusAttrSuccess = attribute.String("status", "success")
-	eventStatusAttrError   = attribute.String("status", "error")
-	errAttrKey             = "error"
+	eventStatusAttrError = attribute.String("status", "error")
+	errAttrKey           = "error"
 )
 
 type Service struct {
@@ -85,7 +84,7 @@ func (s *Service) ValidateToken(ctx context.Context, token string) bool {
 	}
 
 	s.PrincipalID = principalID
-	span.SetAttributes(eventStatusAttrSuccess)
+	span.SetAttributes(attribute.String("status", "success"))
 	span.SetStatus(codes.Ok, "token validated successfully")
 
 	return true


### PR DESCRIPTION
I had been declaring attributes as global vars, but they were only used once so didn't make a lot of sense, and removing this makes the code a little bit more readable IMO.